### PR TITLE
Security Patches :D

### DIFF
--- a/quickstep/AndroidManifest.xml
+++ b/quickstep/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.CONTROL_REMOTE_APP_TRANSITION_ANIMATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <uses-permission android:name="android.permission.ALLOW_SLIPPERY_TOUCHES"/>
     <uses-permission android:name="${packageName}.permission.HOTSEAT_EDU" />
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" />
     <uses-permission android:name="android.permission.FORCE_STOP_PACKAGES" />

--- a/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/StatusBarTouchController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/StatusBarTouchController.java
@@ -20,6 +20,7 @@ import static android.view.MotionEvent.ACTION_MOVE;
 import static android.view.MotionEvent.ACTION_UP;
 import static android.view.MotionEvent.ACTION_CANCEL;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_SWIPE_DOWN_WORKSPACE_NOTISHADE_OPEN;
+import static android.view.WindowManager.LayoutParams.FLAG_SLIPPERY;
 
 import android.graphics.PointF;
 import android.util.SparseArray;
@@ -48,17 +49,6 @@ import java.io.PrintWriter;
 public class StatusBarTouchController implements TouchController {
 
     private static final String TAG = "StatusBarController";
-
-    /**
-     * Window flag: Enable touches to slide out of a window into neighboring
-     * windows in mid-gesture instead of being captured for the duration of
-     * the gesture.
-     *
-     * This flag changes the behavior of touch focus for this window only.
-     * Touches can slide out of the window but they cannot necessarily slide
-     * back in (unless the other window with touch focus permits it).
-     */
-    private static final int FLAG_SLIPPERY = 0x20000000;
 
     private final Launcher mLauncher;
     private final SystemUiProxy mSystemUiProxy;
@@ -145,6 +135,15 @@ public class StatusBarTouchController implements TouchController {
         return true;
     }
 
+    /**
+     * FLAG_SLIPPERY enables touches to slide out of a window into neighboring
+     * windows in mid-gesture instead of being captured for the duration of
+     * the gesture.
+     *
+     * This flag changes the behavior of touch focus for this window only.
+     * Touches can slide out of the window but they cannot necessarily slide
+     * back in (unless the other window with touch focus permits it).
+     */
     private void setWindowSlippery(boolean enable) {
         Window w = mLauncher.getWindow();
         WindowManager.LayoutParams wlp = w.getAttributes();

--- a/src/com/android/launcher3/util/PackageManagerHelper.java
+++ b/src/com/android/launcher3/util/PackageManagerHelper.java
@@ -153,6 +153,18 @@ public class PackageManagerHelper {
      * any permissions
      */
     public boolean hasPermissionForActivity(Intent intent, String srcPackage) {
+        // b/270152142
+        if (Intent.ACTION_CHOOSER.equals(intent.getAction())) {
+            final Bundle extras = intent.getExtras();
+            if (extras == null) {
+                return true;
+            }
+            // If given intent is ACTION_CHOOSER, verify srcPackage has permission over EXTRA_INTENT
+            intent = (Intent) extras.getParcelable(Intent.EXTRA_INTENT);
+            if (intent == null) {
+                return true;
+            }
+        }
         ResolveInfo target = mPm.resolveActivity(intent, 0);
         if (target == null) {
             // Not a valid target


### PR DESCRIPTION
 Add ALLOW_SLIPPERY_TOUCHES to make StatusBarTouchController slippery
LauncherActivity uses FLAG_SLIPPERY for certain interactions. For example, when home screen is shown, and the user pulls down from not the top of the screen, and notification shade is getting displayed, then the touch should be getting transferred to the NotificationShade using FLAG_SLIPPERY.

The newly introduced permission is added to launcher in order for this flag to be applied to the window.

Bug: 206188649
Bug: 157929241
Test: reviewed logs, ensure that NexusLauncherActivity has FLAG_SLIPPERY Test: re-ran the performance regression test
Merged-In: I8d05fa3663687b5382a59b0d47cdac404844c3b7 Change-Id: I8d05fa3663687b5382a59b0d47cdac404844c3b7 (cherry picked from commit 918776ee51c60a1156600bbbcf5da986ef882a91) Merged-In:I8d05fa3663687b5382a59b0d47cdac404844c3b7